### PR TITLE
fix: wrong css properties format and table children

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c0d3-diff",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": false,
   "description": "A fork of react-diff-viewer for c0d3",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c0d3-diff",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": false,
   "description": "A fork of react-diff-viewer for c0d3",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c0d3-diff",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": false,
   "description": "A fork of react-diff-viewer for c0d3",
   "keywords": [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -564,12 +564,13 @@ ReactDiffViewerState
       <tr className={this.styles.titleBlock}>
         <td
           colSpan={splitView ? colSpanOnSplitView : colSpanOnInlineView}
+          className={this.styles.rightTitleBox}
         >
-          <pre className={this.styles.rightTitle}>{leftTitle}</pre>
+          <span className={this.styles.rightTitle}>{leftTitle}</span>
         </td>
         {splitView && (
           <td colSpan={colSpanOnSplitView} className={this.styles.titleBlock}>
-            <pre className={this.styles.rightTitle}>{rightTitle}</pre>
+            <span className={this.styles.rightTitle}>{rightTitle}</span>
           </td>
         )}
         <td className={this.styles.toolbar}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,15 +3,15 @@ import * as PropTypes from 'prop-types';
 import cn from 'classnames';
 
 import {
-	computeLineInformation,
-	LineInformation,
-	DiffInformation,
-	DiffType,
-	DiffMethod,
+  computeLineInformation,
+  LineInformation,
+  DiffInformation,
+  DiffType,
+  DiffMethod,
 } from './compute-lines';
 import computeStyles, {
-	ReactDiffViewerStylesOverride,
-	ReactDiffViewerStyles,
+  ReactDiffViewerStylesOverride,
+  ReactDiffViewerStyles,
 } from './styles';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -20,187 +20,187 @@ const m = require('memoize-one');
 const memoize = m.default || m;
 
 export enum LineNumberPrefix {
-	LEFT = 'L',
-	RIGHT = 'R',
+  LEFT = 'L',
+  RIGHT = 'R',
 }
 
 export interface ReactDiffViewerProps {
-	// Old value to compare.
-	oldValue: string;
-	// New value to compare.
-	newValue: string;
-	// Enable/Disable split view.
-	splitView?: boolean;
-	// Set line Offset
-	linesOffset?: number;
-	// Enable/Disable word diff.
-	disableWordDiff?: boolean;
-	// JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
-	compareMethod?: DiffMethod;
-	// Number of unmodified lines surrounding each line diff.
-	extraLinesSurroundingDiff?: number;
-	// Show/hide line number.
-	hideLineNumbers?: boolean;
-	// Show only diff between the two values.
-	showDiffOnly?: boolean;
-	// Render prop to format final string before displaying them in the UI.
-	renderContent?: (source: string, line: number) => JSX.Element;
-	// Render prop to format code fold message.
-	codeFoldMessageRenderer?: (
-		totalFoldedLines: number,
-		leftStartLineNumber: number,
-		rightStartLineNumber: number,
-	) => JSX.Element;
-	// Event handler for line number click.
-	onLineNumberClick?: (
-		lineId: string,
-		event: React.MouseEvent<HTMLTableCellElement>,
-	) => void;
-	// Array of line ids to highlight lines.
-	highlightLines?: string[];
-	// Style overrides.
-	styles?: ReactDiffViewerStylesOverride;
-	// Use dark theme.
-	useDarkTheme?: boolean;
-	// Title for left column
-	leftTitle?: string | JSX.Element;
-	// Title for left column
-	rightTitle?: string | JSX.Element;
-	// Toolbar
-	toolbar?: () => JSX.Element;
+  // Old value to compare.
+  oldValue: string;
+  // New value to compare.
+  newValue: string;
+  // Enable/Disable split view.
+  splitView?: boolean;
+  // Set line Offset
+  linesOffset?: number;
+  // Enable/Disable word diff.
+  disableWordDiff?: boolean;
+  // JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
+  compareMethod?: DiffMethod;
+  // Number of unmodified lines surrounding each line diff.
+  extraLinesSurroundingDiff?: number;
+  // Show/hide line number.
+  hideLineNumbers?: boolean;
+  // Show only diff between the two values.
+  showDiffOnly?: boolean;
+  // Render prop to format final string before displaying them in the UI.
+  renderContent?: (source: string, line: number) => JSX.Element;
+  // Render prop to format code fold message.
+  codeFoldMessageRenderer?: (
+    totalFoldedLines: number,
+    leftStartLineNumber: number,
+    rightStartLineNumber: number,
+  ) => JSX.Element;
+  // Event handler for line number click.
+  onLineNumberClick?: (
+    lineId: string,
+    event: React.MouseEvent<HTMLTableCellElement>,
+  ) => void;
+  // Array of line ids to highlight lines.
+  highlightLines?: string[];
+  // Style overrides.
+  styles?: ReactDiffViewerStylesOverride;
+  // Use dark theme.
+  useDarkTheme?: boolean;
+  // Title for left column
+  leftTitle?: string | JSX.Element;
+  // Title for left column
+  rightTitle?: string | JSX.Element;
+  // Toolbar
+  toolbar?: () => JSX.Element;
 }
 
 export interface ReactDiffViewerState {
-	// Array holding the expanded code folding.
-	expandedBlocks?: number[];
+  // Array holding the expanded code folding.
+  expandedBlocks?: number[];
 }
 
 class DiffViewer extends React.Component<
-	ReactDiffViewerProps,
-	ReactDiffViewerState
+ReactDiffViewerProps,
+ReactDiffViewerState
 > {
-	private styles: ReactDiffViewerStyles;
+  private styles: ReactDiffViewerStyles;
 
-	public static defaultProps: ReactDiffViewerProps = {
-		oldValue: '',
-		newValue: '',
-		splitView: true,
-		highlightLines: [],
-		disableWordDiff: false,
-		compareMethod: DiffMethod.CHARS,
-		styles: {},
-		hideLineNumbers: false,
-		extraLinesSurroundingDiff: 3,
-		showDiffOnly: true,
-		useDarkTheme: false,
-		linesOffset: 0,
-	};
+  public static defaultProps: ReactDiffViewerProps = {
+    oldValue: '',
+    newValue: '',
+    splitView: true,
+    highlightLines: [],
+    disableWordDiff: false,
+    compareMethod: DiffMethod.CHARS,
+    styles: {},
+    hideLineNumbers: false,
+    extraLinesSurroundingDiff: 3,
+    showDiffOnly: true,
+    useDarkTheme: false,
+    linesOffset: 0,
+  };
 
-	public static propTypes = {
-		oldValue: PropTypes.string.isRequired,
-		newValue: PropTypes.string.isRequired,
-		splitView: PropTypes.bool,
-		disableWordDiff: PropTypes.bool,
-		compareMethod: PropTypes.oneOf(Object.values(DiffMethod)),
-		renderContent: PropTypes.func,
-		onLineNumberClick: PropTypes.func,
-		extraLinesSurroundingDiff: PropTypes.number,
-		styles: PropTypes.object,
-		hideLineNumbers: PropTypes.bool,
-		showDiffOnly: PropTypes.bool,
-		highlightLines: PropTypes.arrayOf(PropTypes.string),
-		leftTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-		rightTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-		linesOffset: PropTypes.number,
-		toolbar: PropTypes.func
-	};
+  public static propTypes = {
+    oldValue: PropTypes.string.isRequired,
+    newValue: PropTypes.string.isRequired,
+    splitView: PropTypes.bool,
+    disableWordDiff: PropTypes.bool,
+    compareMethod: PropTypes.oneOf(Object.values(DiffMethod)),
+    renderContent: PropTypes.func,
+    onLineNumberClick: PropTypes.func,
+    extraLinesSurroundingDiff: PropTypes.number,
+    styles: PropTypes.object,
+    hideLineNumbers: PropTypes.bool,
+    showDiffOnly: PropTypes.bool,
+    highlightLines: PropTypes.arrayOf(PropTypes.string),
+    leftTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    rightTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    linesOffset: PropTypes.number,
+    toolbar: PropTypes.func,
+  };
 
-	public constructor(props: ReactDiffViewerProps) {
-		super(props);
+  public constructor(props: ReactDiffViewerProps) {
+    super(props);
 
-		this.state = {
-			expandedBlocks: [],
-		};
-	}
+    this.state = {
+      expandedBlocks: [],
+    };
+  }
 
-	/**
+  /**
 	 * Resets code block expand to the initial stage. Will be exposed to the parent component via
 	 * refs.
 	 */
-	public resetCodeBlocks = (): boolean => {
-		if (this.state.expandedBlocks.length > 0) {
-			this.setState({
-				expandedBlocks: [],
-			});
-			return true;
-		}
-		return false;
-	};
+  public resetCodeBlocks = (): boolean => {
+    if (this.state.expandedBlocks.length > 0) {
+      this.setState({
+        expandedBlocks: [],
+      });
+      return true;
+    }
+    return false;
+  };
 
-	/**
+  /**
 	 * Pushes the target expanded code block to the state. During the re-render,
 	 * this value is used to expand/fold unmodified code.
 	 */
-	private onBlockExpand = (id: number): void => {
-		const prevState = this.state.expandedBlocks.slice();
-		prevState.push(id);
+  private onBlockExpand = (id: number): void => {
+    const prevState = this.state.expandedBlocks.slice();
+    prevState.push(id);
 
-		this.setState({
-			expandedBlocks: prevState,
-		});
-	};
+    this.setState({
+      expandedBlocks: prevState,
+    });
+  };
 
-	/**
+  /**
 	 * Computes final styles for the diff viewer. It combines the default styles with the user
 	 * supplied overrides. The computed styles are cached with performance in mind.
 	 *
 	 * @param styles User supplied style overrides.
 	 */
-	private computeStyles: (
-		styles: ReactDiffViewerStylesOverride,
-		useDarkTheme: boolean,
-	) => ReactDiffViewerStyles = memoize(computeStyles);
+  private computeStyles: (
+    styles: ReactDiffViewerStylesOverride,
+    useDarkTheme: boolean,
+  ) => ReactDiffViewerStyles = memoize(computeStyles);
 
-	/**
+  /**
 	 * Returns a function with clicked line number in the closure. Returns an no-op function when no
 	 * onLineNumberClick handler is supplied.
 	 *
 	 * @param id Line id of a line.
 	 */
-	private onLineNumberClickProxy = (id: string): any => {
-		if (this.props.onLineNumberClick) {
-			return (e: any): void => this.props.onLineNumberClick(id, e);
-		}
-		return (): void => { };
-	};
+  private onLineNumberClickProxy = (id: string): any => {
+    if (this.props.onLineNumberClick) {
+      return (e: any): void => this.props.onLineNumberClick(id, e);
+    }
+    return (): void => { };
+  };
 
-	/**
+  /**
 	 * Maps over the word diff and constructs the required React elements to show word diff.
 	 *
 	 * @param diffArray Word diff information derived from line information.
 	 * @param renderer Optional renderer to format diff words. Useful for syntax highlighting.
 	 */
-	private renderWordDiff = (
-		diffArray: DiffInformation[],
-		renderer?: (chunk: string) => JSX.Element,
-	): JSX.Element[] => {
-		return diffArray.map(
-			(wordDiff, i): JSX.Element => {
-				return (
-					<span
-						key={i}
-						className={cn(this.styles.wordDiff, {
-							[this.styles.wordAdded]: wordDiff.type === DiffType.ADDED,
-							[this.styles.wordRemoved]: wordDiff.type === DiffType.REMOVED,
-						})}>
-						{renderer ? renderer(wordDiff.value as string) : wordDiff.value}
-					</span>
-				);
-			},
-		);
-	};
+  private renderWordDiff = (
+    diffArray: DiffInformation[],
+    renderer?: (chunk: string) => JSX.Element,
+  ): JSX.Element[] => {
+    return diffArray.map(
+      (wordDiff, i): JSX.Element => {
+        return (
+          <span
+            key={i}
+            className={cn(this.styles.wordDiff, {
+              [this.styles.wordAdded]: wordDiff.type === DiffType.ADDED,
+              [this.styles.wordRemoved]: wordDiff.type === DiffType.REMOVED,
+            })}>
+            {renderer ? renderer(wordDiff.value as string) : wordDiff.value}
+          </span>
+        );
+      },
+    );
+  };
 
-	/**
+  /**
 	 * Maps over the line diff and constructs the required react elements to show line diff. It calls
 	 * renderWordDiff when encountering word diff. This takes care of both inline and split view line
 	 * renders.
@@ -213,88 +213,87 @@ class DiffViewer extends React.Component<
 	 *  diff view. Right line number will be passed as additionalLineNumber.
 	 * @param additionalPrefix Similar to prefix but for additional line number.
 	 */
-	private renderLine = (
-		lineNumber: number,
-		type: DiffType,
-		prefix: LineNumberPrefix,
-		value: string | DiffInformation[],
-		additionalLineNumber?: number,
-		additionalPrefix?: LineNumberPrefix,
-	): JSX.Element => {
-		const lineNumberTemplate = `${prefix}-${lineNumber}`;
-		const additionalLineNumberTemplate = `${additionalPrefix}-${additionalLineNumber}`;
-		const highlightLine =
-			this.props.highlightLines.includes(lineNumberTemplate) ||
-			this.props.highlightLines.includes(additionalLineNumberTemplate);
-		const added = type === DiffType.ADDED;
-		const removed = type === DiffType.REMOVED;
-		let content;
-		if (Array.isArray(value)) {
-			//@ts-ignore
-			content = this.renderWordDiff(value, this.props.renderContent);
-		} else if (this.props.renderContent) {
-			content = this.props.renderContent(value, additionalLineNumber);
-		} else {
-			content = value;
-		}
+  private renderLine = (
+    lineNumber: number,
+    type: DiffType,
+    prefix: LineNumberPrefix,
+    value: string | DiffInformation[],
+    additionalLineNumber?: number,
+    additionalPrefix?: LineNumberPrefix,
+  ): JSX.Element => {
+    const lineNumberTemplate = `${prefix}-${lineNumber}`;
+    const additionalLineNumberTemplate = `${additionalPrefix}-${additionalLineNumber}`;
+    const highlightLine =			this.props.highlightLines.includes(lineNumberTemplate)
+			|| this.props.highlightLines.includes(additionalLineNumberTemplate);
+    const added = type === DiffType.ADDED;
+    const removed = type === DiffType.REMOVED;
+    let content;
+    if (Array.isArray(value)) {
+      // @ts-ignore
+      content = this.renderWordDiff(value, this.props.renderContent);
+    } else if (this.props.renderContent) {
+      content = this.props.renderContent(value, additionalLineNumber);
+    } else {
+      content = value;
+    }
 
-		return (
-			<React.Fragment>
-				{!this.props.hideLineNumbers && (
-					<td
-						onClick={
-							lineNumber && this.onLineNumberClickProxy(lineNumberTemplate)
-						}
-						className={cn(this.styles.gutter, {
-							[this.styles.emptyGutter]: !lineNumber,
-							[this.styles.diffAdded]: added,
-							[this.styles.diffRemoved]: removed,
-							[this.styles.highlightedGutter]: highlightLine,
-						})}>
-						<pre className={this.styles.lineNumber}>{lineNumber}</pre>
-					</td>
-				)}
-				{!this.props.splitView && !this.props.hideLineNumbers && (
-					<td
-						onClick={
-							additionalLineNumber &&
-							this.onLineNumberClickProxy(additionalLineNumberTemplate)
-						}
-						className={cn(this.styles.gutter, {
-							[this.styles.emptyGutter]: !additionalLineNumber,
-							[this.styles.diffAdded]: added,
-							[this.styles.diffRemoved]: removed,
-							[this.styles.highlightedGutter]: highlightLine,
-						})}>
-						<pre className={this.styles.lineNumber}>{additionalLineNumber}</pre>
-					</td>
-				)}
-				<td
-					className={cn(this.styles.marker, {
-						[this.styles.emptyLine]: !content,
-						[this.styles.diffAdded]: added,
-						[this.styles.diffRemoved]: removed,
-						[this.styles.highlightedLine]: highlightLine,
-					})}>
-					<pre>
-						{added && '+'}
-						{removed && '-'}
-					</pre>
-				</td>
-				<td
-					className={cn(this.styles.content, {
-						[this.styles.emptyLine]: !content,
-						[this.styles.diffAdded]: added,
-						[this.styles.diffRemoved]: removed,
-						[this.styles.highlightedLine]: highlightLine,
-					})}>
-					<pre className={this.styles.contentText}>{content}</pre>
-				</td>
-			</React.Fragment>
-		);
-	};
+    return (
+      <React.Fragment>
+        {!this.props.hideLineNumbers && (
+          <td
+            onClick={
+              lineNumber && this.onLineNumberClickProxy(lineNumberTemplate)
+            }
+            className={cn(this.styles.gutter, {
+              [this.styles.emptyGutter]: !lineNumber,
+              [this.styles.diffAdded]: added,
+              [this.styles.diffRemoved]: removed,
+              [this.styles.highlightedGutter]: highlightLine,
+            })}>
+            <pre className={this.styles.lineNumber}>{lineNumber}</pre>
+          </td>
+        )}
+        {!this.props.splitView && !this.props.hideLineNumbers && (
+          <td
+            onClick={
+              additionalLineNumber
+							&& this.onLineNumberClickProxy(additionalLineNumberTemplate)
+            }
+            className={cn(this.styles.gutter, {
+              [this.styles.emptyGutter]: !additionalLineNumber,
+              [this.styles.diffAdded]: added,
+              [this.styles.diffRemoved]: removed,
+              [this.styles.highlightedGutter]: highlightLine,
+            })}>
+            <pre className={this.styles.lineNumber}>{additionalLineNumber}</pre>
+          </td>
+        )}
+        <td
+          className={cn(this.styles.marker, {
+            [this.styles.emptyLine]: !content,
+            [this.styles.diffAdded]: added,
+            [this.styles.diffRemoved]: removed,
+            [this.styles.highlightedLine]: highlightLine,
+          })}>
+          <pre>
+            {added && '+'}
+            {removed && '-'}
+          </pre>
+        </td>
+        <td
+          className={cn(this.styles.content, {
+            [this.styles.emptyLine]: !content,
+            [this.styles.diffAdded]: added,
+            [this.styles.diffRemoved]: removed,
+            [this.styles.highlightedLine]: highlightLine,
+          })}>
+          <pre className={this.styles.contentText}>{content}</pre>
+        </td>
+      </React.Fragment>
+    );
+  };
 
-	/**
+  /**
 	 * Generates lines for split view.
 	 *
 	 * @param obj Line diff information.
@@ -302,29 +301,29 @@ class DiffViewer extends React.Component<
 	 * @param obj.right Life diff information for the right pane of the split view.
 	 * @param index React key for the lines.
 	 */
-	private renderSplitView = (
-		{ left, right }: LineInformation,
-		index: number,
-	): JSX.Element => {
-		return (
-			<tr key={index} className={this.styles.line}>
-				{this.renderLine(
-					left.lineNumber,
-					left.type,
-					LineNumberPrefix.LEFT,
-					left.value,
-				)}
-				{this.renderLine(
-					right.lineNumber,
-					right.type,
-					LineNumberPrefix.RIGHT,
-					right.value,
-				)}
-			</tr>
-		);
-	};
+  private renderSplitView = (
+    { left, right }: LineInformation,
+    index: number,
+  ): JSX.Element => {
+    return (
+      <tr key={index} className={this.styles.line}>
+        {this.renderLine(
+          left.lineNumber,
+          left.type,
+          LineNumberPrefix.LEFT,
+          left.value,
+        )}
+        {this.renderLine(
+          right.lineNumber,
+          right.type,
+          LineNumberPrefix.RIGHT,
+          right.value,
+        )}
+      </tr>
+    );
+  };
 
-	/**
+  /**
 	 * Generates lines for inline view.
 	 *
 	 * @param obj Line diff information.
@@ -332,80 +331,79 @@ class DiffViewer extends React.Component<
 	 * @param obj.right Life diff information for the removed section of the inline view.
 	 * @param index React key for the lines.
 	 */
-	public renderInlineView = (
-		{ left, right }: LineInformation,
-		index: number,
-	): JSX.Element => {
-		let content;
-		if (left.type === DiffType.REMOVED && right.type === DiffType.ADDED) {
-			return (
-				<React.Fragment key={index}>
-					<tr className={this.styles.line}>
-						{this.renderLine(
-							left.lineNumber,
-							left.type,
-							LineNumberPrefix.LEFT,
-							left.value,
-							null,
-						)}
-					</tr>
-					<tr className={this.styles.line}>
-						{this.renderLine(
-							null,
-							right.type,
-							LineNumberPrefix.RIGHT,
-							right.value,
-							right.lineNumber,
-						)}
-					</tr>
-				</React.Fragment>
-			);
-		}
-		if (left.type === DiffType.REMOVED) {
-			content = this.renderLine(
-				left.lineNumber,
-				left.type,
-				LineNumberPrefix.LEFT,
-				left.value,
-				null,
-			);
-		}
-		if (left.type === DiffType.DEFAULT) {
-			content = this.renderLine(
-				left.lineNumber,
-				left.type,
-				LineNumberPrefix.LEFT,
-				left.value,
-				right.lineNumber,
-				LineNumberPrefix.RIGHT,
-			);
-		}
-		if (right.type === DiffType.ADDED) {
-			content = this.renderLine(
-				null,
-				right.type,
-				LineNumberPrefix.RIGHT,
-				right.value,
-				right.lineNumber,
-			);
-		}
+  public renderInlineView = (
+    { left, right }: LineInformation,
+    index: number,
+  ): JSX.Element => {
+    let content;
+    if (left.type === DiffType.REMOVED && right.type === DiffType.ADDED) {
+      return (
+        <React.Fragment key={index}>
+          <tr className={this.styles.line}>
+            {this.renderLine(
+              left.lineNumber,
+              left.type,
+              LineNumberPrefix.LEFT,
+              left.value,
+              null,
+            )}
+          </tr>
+          <tr className={this.styles.line}>
+            {this.renderLine(
+              null,
+              right.type,
+              LineNumberPrefix.RIGHT,
+              right.value,
+              right.lineNumber,
+            )}
+          </tr>
+        </React.Fragment>
+      );
+    }
+    if (left.type === DiffType.REMOVED) {
+      content = this.renderLine(
+        left.lineNumber,
+        left.type,
+        LineNumberPrefix.LEFT,
+        left.value,
+        null,
+      );
+    }
+    if (left.type === DiffType.DEFAULT) {
+      content = this.renderLine(
+        left.lineNumber,
+        left.type,
+        LineNumberPrefix.LEFT,
+        left.value,
+        right.lineNumber,
+        LineNumberPrefix.RIGHT,
+      );
+    }
+    if (right.type === DiffType.ADDED) {
+      content = this.renderLine(
+        null,
+        right.type,
+        LineNumberPrefix.RIGHT,
+        right.value,
+        right.lineNumber,
+      );
+    }
 
-		return (
-			<tr key={index} className={this.styles.line}>
-				{content}
-			</tr>
-		);
-	};
+    return (
+      <tr key={index} className={this.styles.line}>
+        {content}
+      </tr>
+    );
+  };
 
-	/**
+  /**
 	 * Returns a function with clicked block number in the closure.
 	 *
 	 * @param id Cold fold block id.
 	 */
-	private onBlockClickProxy = (id: number): any => (): void =>
-		this.onBlockExpand(id);
+  private onBlockClickProxy = (id: number): any => (): void => this.onBlockExpand(id);
 
-	/**
+  /**
 	 * Generates cold fold block. It also uses the custom message renderer when available to show
 	 * cold fold messages.
 	 *
@@ -414,187 +412,184 @@ class DiffViewer extends React.Component<
 	 * @param leftBlockLineNumber First left line number after the current code fold block.
 	 * @param rightBlockLineNumber First right line number after the current code fold block.
 	 */
-	private renderSkippedLineIndicator = (
-		num: number,
-		blockNumber: number,
-		leftBlockLineNumber: number,
-		rightBlockLineNumber: number,
-	): JSX.Element => {
-		const { hideLineNumbers, splitView } = this.props;
-		const message = this.props.codeFoldMessageRenderer ? (
-			this.props.codeFoldMessageRenderer(
-				num,
-				leftBlockLineNumber,
-				rightBlockLineNumber,
-			)
-		) : (
-			<pre className={this.styles.codeFoldContent}>Expand {num} lines ...</pre>
-		);
-		const content = (
-			<td>
-				<a onClick={this.onBlockClickProxy(blockNumber)} tabIndex={0}>
-					{message}
-				</a>
-			</td>
-		);
-		const isUnifiedViewWithoutLineNumbers = !splitView && !hideLineNumbers;
-		return (
-			<tr
-				key={`${leftBlockLineNumber}-${rightBlockLineNumber}`}
-				className={this.styles.codeFold}>
-				{!hideLineNumbers && <td className={this.styles.codeFoldGutter} />}
-				<td
-					className={cn({
-						[this.styles.codeFoldGutter]: isUnifiedViewWithoutLineNumbers,
-					})}
-				/>
+  private renderSkippedLineIndicator = (
+    num: number,
+    blockNumber: number,
+    leftBlockLineNumber: number,
+    rightBlockLineNumber: number,
+  ): JSX.Element => {
+    const { hideLineNumbers, splitView } = this.props;
+    const message = this.props.codeFoldMessageRenderer ? (
+      this.props.codeFoldMessageRenderer(
+        num,
+        leftBlockLineNumber,
+        rightBlockLineNumber,
+      )
+    ) : (
+      <pre className={this.styles.codeFoldContent}>Expand {num} lines ...</pre>
+    );
+    const content = (
+      <td>
+        <a onClick={this.onBlockClickProxy(blockNumber)} tabIndex={0}>
+          {message}
+        </a>
+      </td>
+    );
+    const isUnifiedViewWithoutLineNumbers = !splitView && !hideLineNumbers;
+    return (
+      <tr
+        key={`${leftBlockLineNumber}-${rightBlockLineNumber}`}
+        className={this.styles.codeFold}>
+        {!hideLineNumbers && <td className={this.styles.codeFoldGutter} />}
+        <td
+          className={cn({
+            [this.styles.codeFoldGutter]: isUnifiedViewWithoutLineNumbers,
+          })}
+        />
 
-				{/* Swap columns only for unified view without line numbers */}
-				{isUnifiedViewWithoutLineNumbers ? (
-					<React.Fragment>
-						<td />
-						{content}
-					</React.Fragment>
-				) : (
-					<React.Fragment>
-						{content}
-						<td />
-					</React.Fragment>
-				)}
+        {/* Swap columns only for unified view without line numbers */}
+        {isUnifiedViewWithoutLineNumbers ? (
+          <React.Fragment>
+            <td />
+            {content}
+          </React.Fragment>
+        ) : (
+          <React.Fragment>
+            {content}
+            <td />
+          </React.Fragment>
+        )}
 
-				<td />
-				<td />
-			</tr>
-		);
-	};
+        <td />
+        <td />
+      </tr>
+    );
+  };
 
-	/**
+  /**
 	 * Generates the entire diff view.
 	 */
-	private renderDiff = (): JSX.Element[] => {
-		const {
-			oldValue,
-			newValue,
-			splitView,
-			disableWordDiff,
-			compareMethod,
-			linesOffset,
-		} = this.props;
-		const { lineInformation, diffLines } = computeLineInformation(
-			oldValue,
-			newValue,
-			disableWordDiff,
-			compareMethod,
-			linesOffset,
-		);
-		const extraLines =
-			this.props.extraLinesSurroundingDiff < 0
-				? 0
-				: this.props.extraLinesSurroundingDiff;
-		let skippedLines: number[] = [];
-		return lineInformation.map(
-			(line: LineInformation, i: number): JSX.Element => {
-				const diffBlockStart = diffLines[0];
-				const currentPosition = diffBlockStart - i;
-				if (this.props.showDiffOnly) {
-					if (currentPosition === -extraLines) {
-						skippedLines = [];
-						diffLines.shift();
-					}
-					if (
-						line.left.type === DiffType.DEFAULT &&
-						(currentPosition > extraLines ||
-							typeof diffBlockStart === 'undefined') &&
-						!this.state.expandedBlocks.includes(diffBlockStart)
-					) {
-						skippedLines.push(i + 1);
-						if (i === lineInformation.length - 1 && skippedLines.length > 1) {
-							return this.renderSkippedLineIndicator(
-								skippedLines.length,
-								diffBlockStart,
-								line.left.lineNumber,
-								line.right.lineNumber,
-							);
-						}
-						return null;
-					}
-				}
+  private renderDiff = (): JSX.Element[] => {
+    const {
+      oldValue,
+      newValue,
+      splitView,
+      disableWordDiff,
+      compareMethod,
+      linesOffset,
+    } = this.props;
+    const { lineInformation, diffLines } = computeLineInformation(
+      oldValue,
+      newValue,
+      disableWordDiff,
+      compareMethod,
+      linesOffset,
+    );
+    const extraLines = this.props.extraLinesSurroundingDiff < 0 ? 0 : this.props.extraLinesSurroundingDiff;
+    let skippedLines: number[] = [];
+    return lineInformation.map(
+      (line: LineInformation, i: number): JSX.Element => {
+        const diffBlockStart = diffLines[0];
+        const currentPosition = diffBlockStart - i;
+        if (this.props.showDiffOnly) {
+          if (currentPosition === -extraLines) {
+            skippedLines = [];
+            diffLines.shift();
+          }
+          if (
+            line.left.type === DiffType.DEFAULT
+						&& (currentPosition > extraLines
+							|| typeof diffBlockStart === 'undefined')
+						&& !this.state.expandedBlocks.includes(diffBlockStart)
+          ) {
+            skippedLines.push(i + 1);
+            if (i === lineInformation.length - 1 && skippedLines.length > 1) {
+              return this.renderSkippedLineIndicator(
+                skippedLines.length,
+                diffBlockStart,
+                line.left.lineNumber,
+                line.right.lineNumber,
+              );
+            }
+            return null;
+          }
+        }
 
-				const diffNodes = splitView
-					? this.renderSplitView(line, i)
-					: this.renderInlineView(line, i);
+        const diffNodes = splitView
+          ? this.renderSplitView(line, i)
+          : this.renderInlineView(line, i);
 
-				if (currentPosition === extraLines && skippedLines.length > 0) {
-					const { length } = skippedLines;
-					skippedLines = [];
-					return (
-						<React.Fragment key={i}>
-							{this.renderSkippedLineIndicator(
-								length,
-								diffBlockStart,
-								line.left.lineNumber,
-								line.right.lineNumber,
-							)}
-							{diffNodes}
-						</React.Fragment>
-					);
-				}
-				return diffNodes;
-			},
-		);
-	};
+        if (currentPosition === extraLines && skippedLines.length > 0) {
+          const { length } = skippedLines;
+          skippedLines = [];
+          return (
+            <React.Fragment key={i}>
+              {this.renderSkippedLineIndicator(
+                length,
+                diffBlockStart,
+                line.left.lineNumber,
+                line.right.lineNumber,
+              )}
+              {diffNodes}
+            </React.Fragment>
+          );
+        }
+        return diffNodes;
+      },
+    );
+  };
 
-	public render = (): JSX.Element => {
-		const {
-			oldValue,
-			newValue,
-			useDarkTheme,
-			leftTitle,
-			rightTitle,
-			splitView,
-			hideLineNumbers,
-			toolbar
-		} = this.props;
+  public render = (): JSX.Element => {
+    const {
+      oldValue,
+      newValue,
+      useDarkTheme,
+      leftTitle,
+      rightTitle,
+      splitView,
+      hideLineNumbers,
+      toolbar,
+    } = this.props;
 
-		if (typeof oldValue !== 'string' || typeof newValue !== 'string') {
-			throw Error('"oldValue" and "newValue" should be strings');
-		}
+    if (typeof oldValue !== 'string' || typeof newValue !== 'string') {
+      throw Error('"oldValue" and "newValue" should be strings');
+    }
 
-		this.styles = this.computeStyles(this.props.styles, useDarkTheme);
-		const nodes = this.renderDiff();
-		const colSpanOnSplitView = hideLineNumbers ? 2 : 3;
-		const colSpanOnInlineView = hideLineNumbers ? 2 : 4;
+    this.styles = this.computeStyles(this.props.styles, useDarkTheme);
+    const nodes = this.renderDiff();
+    const colSpanOnSplitView = hideLineNumbers ? 2 : 3;
+    const colSpanOnInlineView = hideLineNumbers ? 2 : 4;
 
-		const title = (leftTitle || rightTitle) && (
-			<tr>
-				<td className={this.styles.titleBlock}>
-					<td
-						colSpan={splitView ? colSpanOnSplitView : colSpanOnInlineView}
-						>
-						<pre className={this.styles.rightTitle}>{leftTitle}</pre>
-					</td>
-					{splitView && (
-						<td colSpan={colSpanOnSplitView} className={this.styles.titleBlock}>
-							<pre className={this.styles.rightTitle}>{rightTitle}</pre>
-						</td>
-					)}
-					{toolbar && toolbar()}
-				</td>
-			</tr>
-		);
+    const title = (leftTitle || rightTitle) && (
+      <tr className={this.styles.titleBlock}>
+        <td
+          colSpan={splitView ? colSpanOnSplitView : colSpanOnInlineView}
+        >
+          <pre className={this.styles.rightTitle}>{leftTitle}</pre>
+        </td>
+        {splitView && (
+          <td colSpan={colSpanOnSplitView} className={this.styles.titleBlock}>
+            <pre className={this.styles.rightTitle}>{rightTitle}</pre>
+          </td>
+        )}
+        <td className={this.styles.toolbar}>
+          {toolbar && toolbar()}
+        </td>
+      </tr>
+    );
 
-		return (
-			<table
-				className={cn(this.styles.diffContainer, {
-					[this.styles.splitView]: splitView,
-				})}>
-				<tbody>
-					{title}
-					{nodes}
-				</tbody>
-			</table>
-		);
-	};
+    return (
+      <table
+        className={cn(this.styles.diffContainer, {
+          [this.styles.splitView]: splitView,
+        })}>
+        <tbody>
+          {title}
+          {nodes}
+        </tbody>
+      </table>
+    );
+  };
 }
 
 export default DiffViewer;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -479,7 +479,6 @@ class DiffViewer extends React.Component<
 			disableWordDiff,
 			compareMethod,
 			linesOffset,
-			toolbar
 		} = this.props;
 		const { lineInformation, diffLines } = computeLineInformation(
 			oldValue,
@@ -568,7 +567,7 @@ class DiffViewer extends React.Component<
 
 		const title = (leftTitle || rightTitle) && (
 			<tr>
-				<div className={this.styles.titleBlock}>
+				<td className={this.styles.titleBlock}>
 					<td
 						colSpan={splitView ? colSpanOnSplitView : colSpanOnInlineView}
 						>
@@ -580,7 +579,7 @@ class DiffViewer extends React.Component<
 						</td>
 					)}
 					{toolbar && toolbar()}
-				</div>
+				</td>
 			</tr>
 		);
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -195,8 +195,8 @@ export default (
 			color: variables.diffViewerTitleColor,
 		},
 		display: 'flex',
-		'align-items': 'center',
-		'justify-content': 'space-between'
+		alignItems: 'center',
+		justifyContent: 'space-between'
 	});
 
 	const lineNumber = css({

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -79,6 +79,7 @@ export interface ReactDiffViewerStylesOverride {
   splitView?: Interpolation;
   rightTitle?: Interpolation;
   toolbar?: Interpolation;
+  rightTitleBox?: Interpolation;
 }
 
 export default (
@@ -197,8 +198,9 @@ export default (
     },
     alignItems: 'center',
     justifyContent: 'space-between',
-    gridAutoFlow: 'column',
-    display: 'grid',
+    display: 'flex',
+    flexDirection: 'row',
+    minWidth: 0,
   });
 
   const lineNumber = css({
@@ -349,12 +351,19 @@ export default (
   const rightTitle = css({
     color: variables.diffViewerColor,
     label: 'right-title',
+    fontFamily: 'var(--bs-font-monospace)',
+    fontSize: '0.875em',
+  });
+
+  const rightTitleBox = css({
+    minWidth: 0,
+    label: 'right-title-box',
   });
 
   const toolbar = css({
-    display: 'grid',
+    display: 'flex',
     alignItems: 'center',
-    gridAutoFlow: 'column',
+    flexDirection: 'row',
     label: 'toolbar',
   });
 
@@ -382,6 +391,7 @@ export default (
     titleBlock,
     rightTitle,
     toolbar,
+    rightTitleBox,
   };
 
   const computerOverrideStyles: ReactDiffViewerStyles = Object.keys(

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -2,399 +2,409 @@ import { css, cx } from 'emotion';
 import { Interpolation } from 'create-emotion';
 
 export interface ReactDiffViewerStyles {
-	diffContainer?: string;
-	diffRemoved?: string;
-	diffAdded?: string;
-	line?: string;
-	highlightedGutter?: string;
-	contentText?: string;
-	gutter?: string;
-	highlightedLine?: string;
-	lineNumber?: string;
-	marker?: string;
-	wordDiff?: string;
-	wordAdded?: string;
-	wordRemoved?: string;
-	codeFoldGutter?: string;
-	emptyGutter?: string;
-	emptyLine?: string;
-	codeFold?: string;
-	titleBlock?: string;
-	content?: string;
-	splitView?: string;
-	[key: string]: string | undefined;
-	rightTitle?: string;
+  diffContainer?: string;
+  diffRemoved?: string;
+  diffAdded?: string;
+  line?: string;
+  highlightedGutter?: string;
+  contentText?: string;
+  gutter?: string;
+  highlightedLine?: string;
+  lineNumber?: string;
+  marker?: string;
+  wordDiff?: string;
+  wordAdded?: string;
+  wordRemoved?: string;
+  codeFoldGutter?: string;
+  emptyGutter?: string;
+  emptyLine?: string;
+  codeFold?: string;
+  titleBlock?: string;
+  content?: string;
+  splitView?: string;
+  [key: string]: string | undefined;
+  rightTitle?: string;
 }
 
 export interface ReactDiffViewerStylesVariables {
-	diffViewerBackground?: string;
-	diffViewerTitleBackground?: string;
-	diffViewerColor?: string;
-	diffViewerTitleColor?: string;
-	diffViewerTitleBorderColor?: string;
-	addedBackground?: string;
-	addedColor?: string;
-	removedBackground?: string;
-	removedColor?: string;
-	wordAddedBackground?: string;
-	wordRemovedBackground?: string;
-	addedGutterBackground?: string;
-	removedGutterBackground?: string;
-	gutterBackground?: string;
-	gutterBackgroundDark?: string;
-	highlightBackground?: string;
-	highlightGutterBackground?: string;
-	codeFoldGutterBackground?: string;
-	codeFoldBackground?: string;
-	emptyLineBackground?: string;
-	gutterColor?: string;
-	addedGutterColor?: string;
-	removedGutterColor?: string;
-	codeFoldContentColor?: string;
+  diffViewerBackground?: string;
+  diffViewerTitleBackground?: string;
+  diffViewerColor?: string;
+  diffViewerTitleColor?: string;
+  diffViewerTitleBorderColor?: string;
+  addedBackground?: string;
+  addedColor?: string;
+  removedBackground?: string;
+  removedColor?: string;
+  wordAddedBackground?: string;
+  wordRemovedBackground?: string;
+  addedGutterBackground?: string;
+  removedGutterBackground?: string;
+  gutterBackground?: string;
+  gutterBackgroundDark?: string;
+  highlightBackground?: string;
+  highlightGutterBackground?: string;
+  codeFoldGutterBackground?: string;
+  codeFoldBackground?: string;
+  emptyLineBackground?: string;
+  gutterColor?: string;
+  addedGutterColor?: string;
+  removedGutterColor?: string;
+  codeFoldContentColor?: string;
 }
 
 export interface ReactDiffViewerStylesOverride {
-	variables?: {
-		dark?: ReactDiffViewerStylesVariables;
-		light?: ReactDiffViewerStylesVariables;
-	};
-	diffContainer?: Interpolation;
-	diffRemoved?: Interpolation;
-	diffAdded?: Interpolation;
-	marker?: Interpolation;
-	emptyGutter?: Interpolation;
-	highlightedLine?: Interpolation;
-	lineNumber?: Interpolation;
-	highlightedGutter?: Interpolation;
-	contentText?: Interpolation;
-	gutter?: Interpolation;
-	line?: Interpolation;
-	wordDiff?: Interpolation;
-	wordAdded?: Interpolation;
-	wordRemoved?: Interpolation;
-	codeFoldGutter?: Interpolation;
-	emptyLine?: Interpolation;
-	content?: Interpolation;
-	titleBlock?: Interpolation;
-	splitView?: Interpolation;
-	rightTitle?: Interpolation;
+  variables?: {
+    dark?: ReactDiffViewerStylesVariables;
+    light?: ReactDiffViewerStylesVariables;
+  };
+  diffContainer?: Interpolation;
+  diffRemoved?: Interpolation;
+  diffAdded?: Interpolation;
+  marker?: Interpolation;
+  emptyGutter?: Interpolation;
+  highlightedLine?: Interpolation;
+  lineNumber?: Interpolation;
+  highlightedGutter?: Interpolation;
+  contentText?: Interpolation;
+  gutter?: Interpolation;
+  line?: Interpolation;
+  wordDiff?: Interpolation;
+  wordAdded?: Interpolation;
+  wordRemoved?: Interpolation;
+  codeFoldGutter?: Interpolation;
+  emptyLine?: Interpolation;
+  content?: Interpolation;
+  titleBlock?: Interpolation;
+  splitView?: Interpolation;
+  rightTitle?: Interpolation;
+  toolbar?: Interpolation;
 }
 
 export default (
-	styleOverride: ReactDiffViewerStylesOverride,
-	useDarkTheme = false,
+  styleOverride: ReactDiffViewerStylesOverride,
+  useDarkTheme = false,
 ): ReactDiffViewerStyles => {
-	const { variables: overrideVariables = {}, ...styles } = styleOverride;
+  const { variables: overrideVariables = {}, ...styles } = styleOverride;
 
-	const themeVariables = {
-		light: {
-			...{
-				diffViewerBackground: '#fff',
-				diffViewerColor: '#212529',
-				addedBackground: '#e6ffed',
-				addedColor: '#24292e',
-				removedBackground: '#ffeef0',
-				removedColor: '#24292e',
-				wordAddedBackground: '#acf2bd',
-				wordRemovedBackground: '#fdb8c0',
-				addedGutterBackground: '#cdffd8',
-				removedGutterBackground: '#ffdce0',
-				gutterBackground: '#f7f7f7',
-				gutterBackgroundDark: '#f3f1f1',
-				highlightBackground: '#fffbdd',
-				highlightGutterBackground: '#fff5b1',
-				codeFoldGutterBackground: '#dbedff',
-				codeFoldBackground: '#f1f8ff',
-				emptyLineBackground: '#fafbfc',
-				gutterColor: '#212529',
-				addedGutterColor: '#212529',
-				removedGutterColor: '#212529',
-				codeFoldContentColor: '#212529',
-				diffViewerTitleBackground: '#fafbfc',
-				diffViewerTitleColor: '#212529',
-				diffViewerTitleBorderColor: '#eee',
-			},
-			...(overrideVariables.light || {}),
-		},
-		dark: {
-			...{
-				diffViewerBackground: '#2e303c',
-				diffViewerColor: '#FFF',
-				addedBackground: '#044B53',
-				addedColor: 'white',
-				removedBackground: '#632F34',
-				removedColor: 'white',
-				wordAddedBackground: '#055d67',
-				wordRemovedBackground: '#7d383f',
-				addedGutterBackground: '#034148',
-				removedGutterBackground: '#632b30',
-				gutterBackground: '#2c2f3a',
-				gutterBackgroundDark: '#262933',
-				highlightBackground: '#2a3967',
-				highlightGutterBackground: '#2d4077',
-				codeFoldGutterBackground: '#21232b',
-				codeFoldBackground: '#262831',
-				emptyLineBackground: '#363946',
-				gutterColor: '#464c67',
-				addedGutterColor: '#8c8c8c',
-				removedGutterColor: '#8c8c8c',
-				codeFoldContentColor: '#555a7b',
-				diffViewerTitleBackground: '#2f323e',
-				diffViewerTitleColor: '#555a7b',
-				diffViewerTitleBorderColor: '#353846',
-			},
-			...(overrideVariables.dark || {}),
-		},
-	};
+  const themeVariables = {
+    light: {
+      ...{
+        diffViewerBackground: '#fff',
+        diffViewerColor: '#212529',
+        addedBackground: '#e6ffed',
+        addedColor: '#24292e',
+        removedBackground: '#ffeef0',
+        removedColor: '#24292e',
+        wordAddedBackground: '#acf2bd',
+        wordRemovedBackground: '#fdb8c0',
+        addedGutterBackground: '#cdffd8',
+        removedGutterBackground: '#ffdce0',
+        gutterBackground: '#f7f7f7',
+        gutterBackgroundDark: '#f3f1f1',
+        highlightBackground: '#fffbdd',
+        highlightGutterBackground: '#fff5b1',
+        codeFoldGutterBackground: '#dbedff',
+        codeFoldBackground: '#f1f8ff',
+        emptyLineBackground: '#fafbfc',
+        gutterColor: '#212529',
+        addedGutterColor: '#212529',
+        removedGutterColor: '#212529',
+        codeFoldContentColor: '#212529',
+        diffViewerTitleBackground: '#fafbfc',
+        diffViewerTitleColor: '#212529',
+        diffViewerTitleBorderColor: '#eee',
+      },
+      ...(overrideVariables.light || {}),
+    },
+    dark: {
+      ...{
+        diffViewerBackground: '#2e303c',
+        diffViewerColor: '#FFF',
+        addedBackground: '#044B53',
+        addedColor: 'white',
+        removedBackground: '#632F34',
+        removedColor: 'white',
+        wordAddedBackground: '#055d67',
+        wordRemovedBackground: '#7d383f',
+        addedGutterBackground: '#034148',
+        removedGutterBackground: '#632b30',
+        gutterBackground: '#2c2f3a',
+        gutterBackgroundDark: '#262933',
+        highlightBackground: '#2a3967',
+        highlightGutterBackground: '#2d4077',
+        codeFoldGutterBackground: '#21232b',
+        codeFoldBackground: '#262831',
+        emptyLineBackground: '#363946',
+        gutterColor: '#464c67',
+        addedGutterColor: '#8c8c8c',
+        removedGutterColor: '#8c8c8c',
+        codeFoldContentColor: '#555a7b',
+        diffViewerTitleBackground: '#2f323e',
+        diffViewerTitleColor: '#555a7b',
+        diffViewerTitleBorderColor: '#353846',
+      },
+      ...(overrideVariables.dark || {}),
+    },
+  };
 
-	const variables = useDarkTheme ? themeVariables.dark : themeVariables.light;
+  const variables = useDarkTheme ? themeVariables.dark : themeVariables.light;
 
-	const content = css({
-		width: '100%',
-		label: 'content',
-	});
+  const content = css({
+    width: '100%',
+    label: 'content',
+  });
 
-	const splitView = css({
-		[`.${content}`]: {
-			width: '50%',
-		},
-		label: 'split-view',
-	});
+  const splitView = css({
+    [`.${content}`]: {
+      width: '50%',
+    },
+    label: 'split-view',
+  });
 
-	const diffContainer = css({
-		width: '100%',
-		background: variables.diffViewerBackground,
-		pre: {
-			margin: 0,
-			whiteSpace: 'pre-wrap',
-			lineHeight: '25px',
-		},
-		label: 'diff-container',
-		borderCollapse: 'collapse',
-	});
+  const diffContainer = css({
+    width: '100%',
+    background: variables.diffViewerBackground,
+    pre: {
+      margin: 0,
+      whiteSpace: 'pre-wrap',
+      lineHeight: '25px',
+    },
+    label: 'diff-container',
+    borderCollapse: 'collapse',
+  });
 
-	const codeFoldContent = css({
-		color: variables.codeFoldContentColor,
-		label: 'code-fold-content',
-	});
+  const codeFoldContent = css({
+    color: variables.codeFoldContentColor,
+    label: 'code-fold-content',
+  });
 
-	const contentText = css({
-		color: variables.diffViewerColor,
-		label: 'content-text',
-	});
+  const contentText = css({
+    color: variables.diffViewerColor,
+    label: 'content-text',
+  });
 
-	const titleBlock = css({
-		background: variables.diffViewerTitleBackground,
-		padding: '5px 10px',
-		borderBottom: `1px solid ${variables.diffViewerTitleBorderColor}`,
-		label: 'title-block',
-		':last-child': {
-			borderLeft: `1px solid ${variables.diffViewerTitleBorderColor}`,
-		},
-		[`.${contentText}`]: {
-			color: variables.diffViewerTitleColor,
-		},
-		display: 'flex',
-		alignItems: 'center',
-		justifyContent: 'space-between'
-	});
+  const titleBlock = css({
+    background: variables.diffViewerTitleBackground,
+    padding: '5px 10px',
+    borderBottom: `1px solid ${variables.diffViewerTitleBorderColor}`,
+    label: 'title-block',
+    ':last-child': {
+      borderLeft: `1px solid ${variables.diffViewerTitleBorderColor}`,
+    },
+    [`.${contentText}`]: {
+      color: variables.diffViewerTitleColor,
+    },
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gridAutoFlow: 'column',
+    display: 'grid',
+  });
 
-	const lineNumber = css({
-		color: variables.gutterColor,
-		label: 'line-number',
-	});
+  const lineNumber = css({
+    color: variables.gutterColor,
+    label: 'line-number',
+  });
 
-	const diffRemoved = css({
-		background: variables.removedBackground,
-		color: variables.removedColor,
-		pre: {
-			color: variables.removedColor,
-		},
-		[`.${lineNumber}`]: {
-			color: variables.removedGutterColor,
-		},
-		label: 'diff-removed',
-	});
+  const diffRemoved = css({
+    background: variables.removedBackground,
+    color: variables.removedColor,
+    pre: {
+      color: variables.removedColor,
+    },
+    [`.${lineNumber}`]: {
+      color: variables.removedGutterColor,
+    },
+    label: 'diff-removed',
+  });
 
-	const diffAdded = css({
-		background: variables.addedBackground,
-		color: variables.addedColor,
-		pre: {
-			color: variables.addedColor,
-		},
-		[`.${lineNumber}`]: {
-			color: variables.addedGutterColor,
-		},
-		label: 'diff-added',
-	});
+  const diffAdded = css({
+    background: variables.addedBackground,
+    color: variables.addedColor,
+    pre: {
+      color: variables.addedColor,
+    },
+    [`.${lineNumber}`]: {
+      color: variables.addedGutterColor,
+    },
+    label: 'diff-added',
+  });
 
-	const wordDiff = css({
-		padding: 2,
-		display: 'inline-flex',
-		borderRadius: 1,
-		label: 'word-diff',
-	});
+  const wordDiff = css({
+    padding: 2,
+    display: 'inline-flex',
+    borderRadius: 1,
+    label: 'word-diff',
+  });
 
-	const wordAdded = css({
-		background: variables.wordAddedBackground,
-		label: 'word-added',
-	});
+  const wordAdded = css({
+    background: variables.wordAddedBackground,
+    label: 'word-added',
+  });
 
-	const wordRemoved = css({
-		background: variables.wordRemovedBackground,
-		label: 'word-removed',
-	});
+  const wordRemoved = css({
+    background: variables.wordRemovedBackground,
+    label: 'word-removed',
+  });
 
-	const codeFoldGutter = css({
-		backgroundColor: variables.codeFoldGutterBackground,
-		label: 'code-fold-gutter',
-	});
+  const codeFoldGutter = css({
+    backgroundColor: variables.codeFoldGutterBackground,
+    label: 'code-fold-gutter',
+  });
 
-	const codeFold = css({
-		backgroundColor: variables.codeFoldBackground,
-		height: 40,
-		fontSize: 14,
-		fontWeight: 700,
-		label: 'code-fold',
-		a: {
-			textDecoration: 'underline !important',
-			cursor: 'pointer',
-			pre: {
-				display: 'inline',
-			},
-		},
-	});
+  const codeFold = css({
+    backgroundColor: variables.codeFoldBackground,
+    height: 40,
+    fontSize: 14,
+    fontWeight: 700,
+    label: 'code-fold',
+    a: {
+      textDecoration: 'underline !important',
+      cursor: 'pointer',
+      pre: {
+        display: 'inline',
+      },
+    },
+  });
 
-	const emptyLine = css({
-		backgroundColor: variables.emptyLineBackground,
-		label: 'empty-line',
-	});
+  const emptyLine = css({
+    backgroundColor: variables.emptyLineBackground,
+    label: 'empty-line',
+  });
 
-	const marker = css({
-		width: 25,
-		paddingLeft: 10,
-		paddingRight: 10,
-		userSelect: 'none',
-		label: 'marker',
-		[`&.${diffAdded}`]: {
-			pre: {
-				color: variables.addedColor,
-			},
-		},
-		[`&.${diffRemoved}`]: {
-			pre: {
-				color: variables.removedColor,
-			},
-		},
-	});
+  const marker = css({
+    width: 25,
+    paddingLeft: 10,
+    paddingRight: 10,
+    userSelect: 'none',
+    label: 'marker',
+    [`&.${diffAdded}`]: {
+      pre: {
+        color: variables.addedColor,
+      },
+    },
+    [`&.${diffRemoved}`]: {
+      pre: {
+        color: variables.removedColor,
+      },
+    },
+  });
 
-	const highlightedLine = css({
-		background: variables.highlightBackground,
-		label: 'highlighted-line',
-		[`.${wordAdded}, .${wordRemoved}`]: {
-			backgroundColor: 'initial',
-		},
-	});
+  const highlightedLine = css({
+    background: variables.highlightBackground,
+    label: 'highlighted-line',
+    [`.${wordAdded}, .${wordRemoved}`]: {
+      backgroundColor: 'initial',
+    },
+  });
 
-	const highlightedGutter = css({
-		label: 'highlighted-gutter',
-	});
+  const highlightedGutter = css({
+    label: 'highlighted-gutter',
+  });
 
-	const gutter = css({
-		userSelect: 'none',
-		minWidth: 50,
-		padding: '0 10px',
-		label: 'gutter',
-		textAlign: 'right',
-		background: variables.gutterBackground,
-		'&:hover': {
-			cursor: 'pointer',
-			background: variables.gutterBackgroundDark,
-			pre: {
-				opacity: 1,
-			},
-		},
-		pre: {
-			opacity: 0.5,
-		},
-		[`&.${diffAdded}`]: {
-			background: variables.addedGutterBackground,
-		},
-		[`&.${diffRemoved}`]: {
-			background: variables.removedGutterBackground,
-		},
-		[`&.${highlightedGutter}`]: {
-			background: variables.highlightGutterBackground,
-			'&:hover': {
-				background: variables.highlightGutterBackground,
-			},
-		},
-	});
+  const gutter = css({
+    userSelect: 'none',
+    minWidth: 50,
+    padding: '0 10px',
+    label: 'gutter',
+    textAlign: 'right',
+    background: variables.gutterBackground,
+    '&:hover': {
+      cursor: 'pointer',
+      background: variables.gutterBackgroundDark,
+      pre: {
+        opacity: 1,
+      },
+    },
+    pre: {
+      opacity: 0.5,
+    },
+    [`&.${diffAdded}`]: {
+      background: variables.addedGutterBackground,
+    },
+    [`&.${diffRemoved}`]: {
+      background: variables.removedGutterBackground,
+    },
+    [`&.${highlightedGutter}`]: {
+      background: variables.highlightGutterBackground,
+      '&:hover': {
+        background: variables.highlightGutterBackground,
+      },
+    },
+  });
 
-	const emptyGutter = css({
-		'&:hover': {
-			background: variables.gutterBackground,
-			cursor: 'initial',
-		},
-		label: 'empty-gutter',
-	});
+  const emptyGutter = css({
+    '&:hover': {
+      background: variables.gutterBackground,
+      cursor: 'initial',
+    },
+    label: 'empty-gutter',
+  });
 
-	const line = css({
-		verticalAlign: 'baseline',
-		label: 'line',
-	});
+  const line = css({
+    verticalAlign: 'baseline',
+    label: 'line',
+  });
 
-	const rightTitle = css({
-		color: variables.diffViewerColor,
-		label: 'right-title',
-	})
+  const rightTitle = css({
+    color: variables.diffViewerColor,
+    label: 'right-title',
+  });
 
-	const defaultStyles: any = {
-		diffContainer,
-		diffRemoved,
-		diffAdded,
-		splitView,
-		marker,
-		highlightedGutter,
-		highlightedLine,
-		gutter,
-		line,
-		wordDiff,
-		wordAdded,
-		wordRemoved,
-		codeFoldGutter,
-		codeFold,
-		emptyGutter,
-		emptyLine,
-		lineNumber,
-		contentText,
-		content,
-		codeFoldContent,
-		titleBlock,
-		rightTitle
-	};
+  const toolbar = css({
+    display: 'grid',
+    alignItems: 'center',
+    gridAutoFlow: 'column',
+    label: 'toolbar',
+  });
 
-	const computerOverrideStyles: ReactDiffViewerStyles = Object.keys(
-		styles,
-	).reduce(
-		(acc, key): ReactDiffViewerStyles => ({
-			...acc,
-			...{
-				[key]: css((styles as any)[key]),
-			},
-		}),
-		{},
-	);
+  const defaultStyles: any = {
+    diffContainer,
+    diffRemoved,
+    diffAdded,
+    splitView,
+    marker,
+    highlightedGutter,
+    highlightedLine,
+    gutter,
+    line,
+    wordDiff,
+    wordAdded,
+    wordRemoved,
+    codeFoldGutter,
+    codeFold,
+    emptyGutter,
+    emptyLine,
+    lineNumber,
+    contentText,
+    content,
+    codeFoldContent,
+    titleBlock,
+    rightTitle,
+    toolbar,
+  };
 
-	return Object.keys(defaultStyles).reduce(
-		(acc, key): ReactDiffViewerStyles => ({
-			...acc,
-			...{
-				[key]: computerOverrideStyles[key]
-					? cx(defaultStyles[key], computerOverrideStyles[key])
-					: defaultStyles[key],
-			},
-		}),
-		{},
-	);
+  const computerOverrideStyles: ReactDiffViewerStyles = Object.keys(
+    styles,
+  ).reduce(
+    (acc, key): ReactDiffViewerStyles => ({
+      ...acc,
+      ...{
+        [key]: css((styles as any)[key]),
+      },
+    }),
+    {},
+  );
+
+  return Object.keys(defaultStyles).reduce(
+    (acc, key): ReactDiffViewerStyles => ({
+      ...acc,
+      ...{
+        [key]: computerOverrideStyles[key]
+          ? cx(defaultStyles[key], computerOverrideStyles[key])
+          : defaultStyles[key],
+      },
+    }),
+    {},
+  );
 };


### PR DESCRIPTION
This PR fix the following two issues:

- `<div> can't be a child of <table>`
- `css properties names must be in camel-case`