### PR TITLE
fix: Toolbar wrapping

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -201,6 +201,7 @@ export default (
     display: 'flex',
     flexDirection: 'row',
     minWidth: 0,
+    gridAutoFlow: 'column',
   });
 
   const lineNumber = css({


### PR DESCRIPTION
The `title-block` has display of `grid`. To prevent it from wrapping, it should have the following property:

```css
 gridAutoFlow: 'column',
```

`grid-auto-flow` specify the auto-placement algorithm.